### PR TITLE
Added fix for missing thumbnailImageData

### DIFF
--- a/RNUnifiedContacts/RNUnifiedContacts.swift
+++ b/RNUnifiedContacts/RNUnifiedContacts.swift
@@ -154,7 +154,7 @@ class RNUnifiedContacts: NSObject {
     contact["familyName"]         = cNContact.familyName
     contact["imageDataAvailable"] = cNContact.imageDataAvailable
     
-    if (cNContact.imageDataAvailable) {
+    if (cNContact.thumbnailImageData != nil) {
       let thumbnailImageDataAsBase64String = cNContact.thumbnailImageData!.base64EncodedStringWithOptions([])
       contact["thumbnailImageData"] = thumbnailImageDataAsBase64String
       


### PR DESCRIPTION
This fixes issue with crash due the fact that `imageDataAvailable` could be `True` even if `thumbnailImageData` is `nil`.