### PR TITLE
Fix indentation of workflow explanation 

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,9 @@ This will do everything you'd expect. Here's the workflow:
 
      1. If the User has not been asked before (first time asking), prompt user for access:
 
-       1. Yes. Return `true`.
+        1. Yes. Return `true`.
 
-       2. No. Return `false`.
+        2. No. Return `false`.
 
      2. If user has already denied access to Contacts, return `false`.
 


### PR DESCRIPTION
Indentation of "No. Return false." in the "Request Access To Contacts" readme section was incorrect (please look at the interpreted version - it seems fine in the markdown)