### PR TITLE
Support Pre 0.40 and Post 0.40 React Native.

### DIFF
--- a/RNUnifiedContacts/RNUnifiedContacts-Bridging-Header.h
+++ b/RNUnifiedContacts/RNUnifiedContacts-Bridging-Header.h
@@ -9,7 +9,11 @@
 #ifndef RNUnifiedContacts_Bridging_Header_h
 #define RNUnifiedContacts_Bridging_Header_h
 
+#if __has_include("RCTBridgeModule.h")
+#import "RCTBridgeModule.h"
+#else
 #import <React/RCTBridgeModule.h>
+#endif
 
 #endif /* RNUnifiedContacts_Bridging_Header_h */
 


### PR DESCRIPTION
Handle if else for importing `React/RCTBridgeModule.h`.

Fixes #22 