### PR TITLE
Add ability to add and update postal addresses

### DIFF
--- a/RNUnifiedContacts/RNUnifiedContacts.swift
+++ b/RNUnifiedContacts/RNUnifiedContacts.swift
@@ -231,6 +231,12 @@ class RNUnifiedContacts: NSObject {
             mutableContact.emailAddresses.append( emailAddressAsCNLabeledValue )
         }
 
+        for postalAddress in contactData["postalAddresses"] as! NSArray {
+            let postalAddressAsCNLabeledValue = convertPostalAddressToCNLabeledValue ( postalAddress as! NSDictionary )
+
+            mutableContact.postalAddresses.append( postalAddressAsCNLabeledValue )
+        }
+
         do {
 
             saveRequest.add(mutableContact, toContainerWithIdentifier:nil)
@@ -314,6 +320,16 @@ class RNUnifiedContacts: NSObject {
                 let emailAddressAsCNLabeledValue = convertEmailAddressToCNLabeledValue ( emailAddress as! NSDictionary )
 
                 mutableContact.emailAddresses.append( emailAddressAsCNLabeledValue )
+            }
+        }
+
+        if ( contactData["postalAddresses"] != nil ) {
+            mutableContact.postalAddresses.removeAll()
+
+            for postalAddress in contactData["postalAddresses"] as! NSArray {
+                let postalAddressAsCNLabeledValue = convertPostalAddressToCNLabeledValue ( postalAddress as! NSDictionary )
+
+                mutableContact.postalAddresses.append( postalAddressAsCNLabeledValue )
             }
         }
 
@@ -729,6 +745,33 @@ class RNUnifiedContacts: NSObject {
         return CNLabeledValue(
             label:label,
             value: emailAddress["value"] as! NSString
+        )
+    }
+
+        func convertPostalAddressToCNLabeledValue(_ postalAddress: NSDictionary) -> CNLabeledValue<CNPostalAddress> {
+        var label = String()
+        switch (postalAddress["label"] as! String) {
+        case "home":
+            label = CNLabelHome
+        case "work":
+            label = CNLabelWork
+        case "other":
+            label = CNLabelOther
+        default:
+            label = ""
+        }
+
+        let mutableAddress = CNMutablePostalAddress()
+        let userAddressUpdates = postalAddress["value"] as! [String: Any]
+        mutableAddress.street = userAddressUpdates["street"] as! String
+        mutableAddress.city = userAddressUpdates["city"] as! String
+        mutableAddress.state = userAddressUpdates["state"] as! String
+        mutableAddress.postalCode = userAddressUpdates["postalCode"] as! String
+        mutableAddress.country = userAddressUpdates["country"] as! String
+ 
+        return CNLabeledValue(
+            label: label,
+            value: address as CNPostalAddress
         )
     }
 

--- a/RNUnifiedContacts/RNUnifiedContactsBridge.m
+++ b/RNUnifiedContacts/RNUnifiedContactsBridge.m
@@ -35,6 +35,11 @@
               @"ICLOUD"   : @"iCloud",
               @"OTHER"    : @"other",
               },
+          @"postalAddressLabel": @{
+              @"HOME"     : @"home",
+              @"WORK"     : @"work",
+              @"OTHER"    : @"other",
+              },
          };
 }
 


### PR DESCRIPTION
Adds postal addresses to the addContact and updateContact methods.

Note: I did not know if you also wanted to include other properties
like ISOCountryCode or if those are provided by iOS