### PR TITLE
Respect the user addressbook label

### DIFF
--- a/RNUnifiedContacts/RNUnifiedContacts.swift
+++ b/RNUnifiedContacts/RNUnifiedContacts.swift
@@ -691,7 +691,7 @@ class RNUnifiedContacts: NSObject {
             formattedLabel = CNLabelWork
         case "mobile":
             formattedLabel = CNLabelPhoneNumberMobile
-        case "iPhone":
+        case "iphone":
             formattedLabel = CNLabelPhoneNumberiPhone
         case "main":
             formattedLabel = CNLabelPhoneNumberMain
@@ -722,7 +722,7 @@ class RNUnifiedContacts: NSObject {
             formattedLabel = CNLabelHome
         case "work":
             formattedLabel = CNLabelWork
-        case "iCloud":
+        case "icloud":
             formattedLabel = CNLabelEmailiCloud
         case "other":
             formattedLabel = CNLabelOther

--- a/RNUnifiedContacts/RNUnifiedContacts.swift
+++ b/RNUnifiedContacts/RNUnifiedContacts.swift
@@ -681,53 +681,57 @@ class RNUnifiedContacts: NSObject {
     }
 
     func convertPhoneNumberToCNLabeledValue(_ phoneNumber: NSDictionary) -> CNLabeledValue<CNPhoneNumber> {
-        var label = String()
-        switch (phoneNumber["label"] as! String) {
+        var formattedLabel = String()
+        let userProvidedLabel = phoneNumber["label"] as! String
+        let lowercaseUserProvidedLabel = userProvidedLabel.lowercased()
+        switch (lowercaseUserProvidedLabel) {
         case "home":
-            label = CNLabelHome
+            formattedLabel = CNLabelHome
         case "work":
-            label = CNLabelWork
+            formattedLabel = CNLabelWork
         case "mobile":
-            label = CNLabelPhoneNumberMobile
+            formattedLabel = CNLabelPhoneNumberMobile
         case "iPhone":
-            label = CNLabelPhoneNumberiPhone
+            formattedLabel = CNLabelPhoneNumberiPhone
         case "main":
-            label = CNLabelPhoneNumberMain
+            formattedLabel = CNLabelPhoneNumberMain
         case "home fax":
-            label = CNLabelPhoneNumberHomeFax
+            formattedLabel = CNLabelPhoneNumberHomeFax
         case "work fax":
-            label = CNLabelPhoneNumberWorkFax
+            formattedLabel = CNLabelPhoneNumberWorkFax
         case "pager":
-            label = CNLabelPhoneNumberPager
+            formattedLabel = CNLabelPhoneNumberPager
         case "other":
-            label = CNLabelOther
+            formattedLabel = CNLabelOther
         default:
-            label = ""
+            formattedLabel = userProvidedLabel
         }
 
         return CNLabeledValue(
-            label:label,
+            label:formattedLabel,
             value:CNPhoneNumber(stringValue: phoneNumber["stringValue"] as! String)
         )
     }
 
     func convertEmailAddressToCNLabeledValue(_ emailAddress: NSDictionary) -> CNLabeledValue<NSString> {
-        var label = String()
-        switch (emailAddress["label"] as! String) {
+        var formattedLabel = String()
+        let userProvidedLabel = emailAddress["label"] as! String
+        let lowercaseUserProvidedLabel = userProvidedLabel.lowercased()
+        switch (lowercaseUserProvidedLabel) {
         case "home":
-            label = CNLabelHome
+            formattedLabel = CNLabelHome
         case "work":
-            label = CNLabelWork
+            formattedLabel = CNLabelWork
         case "iCloud":
-            label = CNLabelEmailiCloud
+            formattedLabel = CNLabelEmailiCloud
         case "other":
-            label = CNLabelOther
+            formattedLabel = CNLabelOther
         default:
-            label = ""
+            formattedLabel = userProvidedLabel
         }
 
         return CNLabeledValue(
-            label:label,
+            label:formattedLabel,
             value: emailAddress["value"] as! NSString
         )
     }


### PR DESCRIPTION
This PR allows the user to have any label they like (iOS allows for
custom labels).

It also fixes a bug here if the user’s label contained a capital letter (i.e. "Home" instead of "home", this
check did not correctly match the label.

Lastly if fixes a bug that completely erases the user's label if it did not match one of the preformatted options.