### PR TITLE
Add method for checking if we have already checked permission

### DIFF
--- a/RNUnifiedContacts/RNUnifiedContacts.swift
+++ b/RNUnifiedContacts/RNUnifiedContacts.swift
@@ -80,6 +80,18 @@ class RNUnifiedContacts: NSObject {
         }
     }
 
+    @objc func alreadyRequestedAccessToContacts(_ callback: (Array<Bool>) -> ()) -> Void {
+        let authorizationStatus = CNContactStore.authorizationStatus(for: CNEntityType.contacts)
+
+        switch authorizationStatus{
+        case .notDetermined:
+            callback([false])
+
+        case .authorized, .restricted, .denied:
+            callback([true])
+        }
+    }
+
     @objc func getContact(_ identifier: String, callback: (NSArray) -> () ) -> Void {
         let cNContact = getCNContact( identifier, keysToFetch: keysToFetch as [CNKeyDescriptor] )
         if ( cNContact == nil ) {

--- a/RNUnifiedContacts/RNUnifiedContactsBridge.m
+++ b/RNUnifiedContacts/RNUnifiedContactsBridge.m
@@ -78,6 +78,8 @@ RCT_EXTERN_METHOD(userCanAccessContacts:(RCTResponseSenderBlock)callback);
 
 RCT_EXTERN_METHOD(requestAccessToContacts:(RCTResponseSenderBlock)callback);
 
+RCT_EXTERN_METHOD(alreadyRequestedAccessToContacts:(RCTResponseSenderBlock)callback);
+
 RCT_EXPORT_METHOD(openPrivacySettings) {
   [[UIApplication sharedApplication] openURL:[NSURL URLWithString:UIApplicationOpenSettingsURLString]];
 }


### PR DESCRIPTION
This PR adds a method for allowing a developer to check if we have
already checked for permissions.

This allows the developer to treat the UI in the “third state”, where
it’s not “yes” or “no” to contacts, but also “undefined”.

This allows to developer to create UI such as “Request Access to
Contacts” vs “You have chosen to not allow contacts”. Right now, there
is only truthy/falsy