### PR TITLE
Removed usage of CNContactNoteKey

### DIFF
--- a/RNUnifiedContacts/RNUnifiedContacts.swift
+++ b/RNUnifiedContacts/RNUnifiedContacts.swift
@@ -32,7 +32,7 @@ class RNUnifiedContacts: NSObject {
         CNContactNameSuffixKey,
         CNContactNicknameKey,
         CNContactNonGregorianBirthdayKey,
-        // CNContactNoteKey,
+        // CNContactNoteKey, // NOTE: iOS 13 does not allow fetching of notes without the com.apple.developer.contacts.notes entitlement, which requires special permission from Apple.
         CNContactOrganizationNameKey,
         CNContactPhoneNumbersKey,
         CNContactPhoneticFamilyNameKey,
@@ -640,6 +640,7 @@ class RNUnifiedContacts: NSObject {
             contact["nonGregorianBirthday"] = date
         }
 
+        // addString(&contact, key: "note", value: cNContact.note) // NOTE: iOS 13 does not allow fetching of notes without the com.apple.developer.contacts.notes entitlement, which requires special permission from Apple.
         addString(&contact, key: "organizationName", value: cNContact.organizationName)
 
         if cNContact.phoneNumbers.count > 0 {

--- a/RNUnifiedContacts/RNUnifiedContacts.swift
+++ b/RNUnifiedContacts/RNUnifiedContacts.swift
@@ -32,7 +32,7 @@ class RNUnifiedContacts: NSObject {
         CNContactNameSuffixKey,
         CNContactNicknameKey,
         CNContactNonGregorianBirthdayKey,
-        CNContactNoteKey,
+        // CNContactNoteKey,
         CNContactOrganizationNameKey,
         CNContactPhoneNumbersKey,
         CNContactPhoneticFamilyNameKey,
@@ -640,7 +640,6 @@ class RNUnifiedContacts: NSObject {
             contact["nonGregorianBirthday"] = date
         }
 
-        addString(&contact, key: "note", value: cNContact.note)
         addString(&contact, key: "organizationName", value: cNContact.organizationName)
 
         if cNContact.phoneNumbers.count > 0 {


### PR DESCRIPTION
Hi there, while fetching contacts I've encountered error on iOS 13 related with [com.apple.developer.contacts.notes](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_contacts_notes), and I've just removed the usage of _CNContactNoteKey_ and removed one line of code using it, and fetching contacts works again. So this is just small PR for that :)
And of course thanks for this lib!!

Fixes #95.